### PR TITLE
feat: changesets signed commits rollout attempt 2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to NPM
         id: changesets
-        uses: changesets/action@f13b1baaa620fde937751f5d2c3572b9da32af23
+        uses: smartcontractkit/.github/actions/signed-commits@2ad717a39e5007bcdc4168e970ca21983c046a0e # changesets-signed-commits@1.0.2
         with:
           publish: npx changeset publish
         env:
@@ -83,9 +83,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           # We need to checkout main again because the changesets action
-          # consumes the changesets via "changeset version", but we 
+          # consumes the changesets via "changeset version", but we
           # want to do a snapshot versioning instead, hence checking out
           # main again.
-          git checkout main 
+          git checkout main
           npx changeset version --snapshot
           npx changeset publish --tag dev


### PR DESCRIPTION
Follow up from #52, and #54.

This applies a fix to the reverted commit, pulling in the patched version of the `signed-commits` action. 

The fix for this action can be seen here: https://github.com/smartcontractkit/.github/pull/134