### PR TITLE
Issue#56 response listener hangs

### DIFF
--- a/.changeset/silly-berries-beam.md
+++ b/.changeset/silly-berries-beam.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/functions-toolkit': patch
+---
+
+Change default minimum confirmations from listenForResponseFromTransaction() to 1.

--- a/README.md
+++ b/README.md
@@ -452,20 +452,22 @@ functionsRouterAddress,
 
 To listen for a response to a single Functions request, use the `listenForResponseFromTransaction()` method.
 Optionally, you can provide:
-- timeout after which the listener will throw an error indicating that the time limit was exceeded (default 5 minutes) 
-- number of block confirmations (default 2)
-- frequency of checking if the request is already included on-chain (or if it got moved after a chain re-org) (default 2 seconds)
+
+- timeout after which the listener will throw an error indicating that the time limit was exceeded (default 5 minutes expressed in milliseconds)
+- number of block confirmations (default 1, but note that should be 2 or more to for higher confidence in finality, and to protect against reorgs)
+- frequency of checking if the request is already included on-chain (or if it got moved after a chain re-org) (default 2 seconds, but note that `checkInterval`s higher than block time could cause this listener to hang as the response will have completed before the next check.)
 
 ```
 const response: FunctionsResponse = await responseListener.listenForResponseFromTransaction(
   txHash: string,
-  timeout?: number,
+  timeoutMs?: number, // milliseconds
   confirmations?: number,
   checkInterval?: number,
 )
 ```
 
 `listenForResponseFromTransaction()` returns a response with the following structure:
+
 ```
 {
   requestId: string // Request ID of the fulfilled request represented as a bytes32 hex string
@@ -480,7 +482,8 @@ const response: FunctionsResponse = await responseListener.listenForResponseFrom
 
 Alternatively, to listen using a request ID, use the `listenForResponse()` method.
 
-**Notes:** 
+**Notes:**
+
 1. Request ID can change during a chain re-org so it's less reliable than a request transaction hash.
 2. If the methods are called after the response is already on chain, it won't be returned correctly.
 3. Listening for multiple responses simultaneously is not supported by the above methods and will lead to undefined behavior.
@@ -578,6 +581,7 @@ Any 3rd party imports used in the JavaScript source code are loaded asynchronous
 const { format } = await import("npm:date-fns");
 return Functions.encodeString(format(new Date(), "yyyy-MM-dd"));
 ```
+
 ```
 const { escape } = await import("https://deno.land/std/regexp/mod.ts");
 return Functions.encodeString(escape("$hello*world?"));
@@ -720,6 +724,6 @@ const functionsRequestBytesHexString: string = buildRequestCBOR({
 })
 ```
 
-
 ## Browser use
-This package can also be used in most modern web browsers. You can import the package in your front-end application, and call the APIs as you would in a back end NodeJs/Deno environment.  
+
+This package can also be used in most modern web browsers. You can import the package in your front-end application, and call the APIs as you would in a back end NodeJs/Deno environment.

--- a/src/ResponseListener.ts
+++ b/src/ResponseListener.ts
@@ -65,7 +65,7 @@ export class ResponseListener {
 
   /**
    *
-   * @param txHash Transaction hash for the Functions Request
+   * @param txHash Tx hash for the Functions Request
    * @param timeoutMs after which the listener throws, indicating  the time limit was exceeded (default 5 minutes)
    * @param confirmations  number of confirmations to wait for before considering the transaction successful (default 1, but recommend 2 or more)
    * @param checkIntervalMs frequency of checking if the Tx is  included on-chain (or if it got moved after a chain re-org) (default 2 seconds. Intervals longer than block time may cause the listener to wait indefinitely.)


### PR DESCRIPTION
Suggested Fix for Issue: https://github.com/smartcontractkit/functions-toolkit/issues/56

Makes changes to code introduced in PR https://github.com/smartcontractkit/functions-toolkit/pull/36

Things to note:
    1. 2 confirmations is a sensible default but have made 1 to reduce friction for devs so it works out of the box with local functions testnet.
    2. Alternative could be to check inside `listenForResponseFromTransaction()` for ChainID 1337 (local funcs testnet) and then change the default confirmations to 1.
    3. DevX Improvement: . README updates and added inline docs to the function so that it shows on however in the IDE

**However**:
- rather than reducing default confirmations to 1, we could just document LocalFunctionsTestnet more expressly. 
- on the other hand devX will be improved by making default confirmations 1 as it will work out the box.